### PR TITLE
Add WGSL parser coverage baseline

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ dokka = "2.2.0"
 
 # Tests
 kotest = "6.1.11"
+kover = "0.9.8"
 ksp = "2.3.4"
 clikt = "5.0.2"
 
@@ -56,6 +57,7 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 
 # Tests
 kotest = { id = "io.kotest", version.ref = "kotest" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 
 [bundles]

--- a/wgsl/parser/README.md
+++ b/wgsl/parser/README.md
@@ -15,6 +15,7 @@
 7. [Integration](#-integration)
 8. [Examples](#-examples)
 9. [Module Dependencies](#-module-dependencies)
+10. [Coverage](docs/WGSL_PARSER_COVERAGE.md)
 
 ---
 

--- a/wgsl/parser/build.gradle.kts
+++ b/wgsl/parser/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     kotlin("multiplatform")
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotest)
+    alias(libs.plugins.kover)
     alias(libs.plugins.ksp)
 }
 
@@ -100,6 +101,18 @@ java {
     }
 }
 
+kover {
+    reports {
+        variant("jvm") {
+            verify {
+                rule("WGSL parser JVM line coverage") {
+                    minBound(65)
+                }
+            }
+        }
+    }
+}
+
 
 tasks.withType<Test>().configureEach {
     filter {
@@ -123,4 +136,8 @@ tasks.named<Test>("jvmTest") {
         )
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     }
+}
+
+tasks.named("check") {
+    dependsOn("koverVerifyJvm")
 }

--- a/wgsl/parser/docs/WGSL_PARSER_COVERAGE.md
+++ b/wgsl/parser/docs/WGSL_PARSER_COVERAGE.md
@@ -1,0 +1,57 @@
+# WGSL Parser Test Coverage
+
+## Objectif
+
+Le module `:wgsl:parser` dispose maintenant d'une baseline de couverture JVM mesurable et verifiable par Gradle. Cette baseline sert de garde-fou CI pour eviter les regressions pendant la correction du ticket #16.
+
+L'objectif produit reste une couverture metier exhaustive du parseur WGSL. Le seuil actuel n'est donc pas une definition de "done" a 100%, mais le point de depart mesure pour les tranches suivantes.
+
+## Baseline actuelle
+
+| Scope | Commande | Resultat verifie |
+|-------|----------|------------------|
+| Tests unitaires parser JVM | `rtk ./gradlew :wgsl:parser:jvmTest` | 682 tests, 0 failure |
+| Couverture lignes JVM | `rtk ./gradlew :wgsl:parser:koverLogJvm` | 65.022% |
+| Seuil de verification | `rtk ./gradlew :wgsl:parser:koverVerifyJvm` | minimum 65% |
+
+La couverture Kover est limitee aux tests JVM. Les sources communes executees par `jvmTest` sont incluses, mais les tests JS, Native, Android device et Wasm ne sont pas mesures par cette baseline.
+
+## Commandes
+
+Generer le rapport XML JVM:
+
+```bash
+rtk ./gradlew :wgsl:parser:koverXmlReportJvm
+```
+
+Generer le rapport HTML JVM:
+
+```bash
+rtk ./gradlew :wgsl:parser:koverHtmlReportJvm
+```
+
+Afficher la couverture dans les logs:
+
+```bash
+rtk ./gradlew :wgsl:parser:koverLogJvm
+```
+
+Verifier le seuil CI:
+
+```bash
+rtk ./gradlew :wgsl:parser:koverVerifyJvm
+```
+
+Le task `:wgsl:parser:check` depend aussi de `:wgsl:parser:koverVerifyJvm`.
+
+## Strategie vers 100%
+
+Les prochaines corrections doivent privilegier des tests unitaires avec une dimension metier:
+
+- lexer: tokens WGSL spec, erreurs lexicales, commentaires, nombres, identifiants, attributs;
+- parser: declarations, types, expressions, statements, diagnostics et recovery;
+- resolver: noms, types, enums, predeclared enumerants, abstract numeric types;
+- lowering: absence de fallback silencieux, erreurs explicites, preservation des types et bindings;
+- integration: execution de tous les goldens WGSL disponibles et comparaison reproductible.
+
+Chaque hausse de couverture doit relever le seuil `koverVerifyJvm` au niveau mesure, arrondi prudemment a l'entier inferieur, pour rendre la progression non regressionnelle.


### PR DESCRIPTION
Refs #16

## Scope
- Add Kover 0.9.8 to the version catalog and apply it to `:wgsl:parser`.
- Add a JVM line coverage verification rule at the measured 65% baseline.
- Wire `:wgsl:parser:check` to enforce `:wgsl:parser:koverVerifyJvm`.
- Document coverage commands, JVM-only scope, and the path toward business-focused 100% coverage.

## Validation
- `rtk ./gradlew :wgsl:parser:koverXmlReportJvm :wgsl:parser:koverLogJvm`
- `rtk ./gradlew :wgsl:parser:koverVerifyJvm`
- `rtk ./gradlew :wgsl:parser:check :wgsl:parser:koverXmlReportJvm :wgsl:parser:koverHtmlReportJvm`
- Review agent: `APPROVE_MERGE`

## Notes
- Current measured JVM line coverage is 65.022%; the enforced threshold is intentionally rounded down to 65%.
- Kover coverage is JVM-only; JS, Native, Android device, and Wasm tests are outside this baseline.