### PR TITLE
Support Unicode identifiers in WGSL parser

### DIFF
--- a/wgsl/parser/src/commonMain/kotlin/lexer/Lexer.kt
+++ b/wgsl/parser/src/commonMain/kotlin/lexer/Lexer.kt
@@ -180,13 +180,9 @@ class Lexer(
                     Token.simple(TokenKind.SLASH, spanFrom(start))
                 }
             }
-
-            // Identifiers and keywords
-            in 'a'..'z', in 'A'..'Z' -> lexIdentifierOrKeyword(start)
-
             // Special handling for underscore
             '_' -> {
-                if (peekChar(1)?.let { it in 'a'..'z' || it in 'A'..'Z' || it == '_' || it in '0'..'9' } == true) {
+                if (peekChar(1)?.isIdentifierContinue() == true) {
                     lexIdentifierOrKeyword(start)
                 } else {
                     consume()
@@ -229,8 +225,10 @@ class Lexer(
                 Token.simple(TokenKind.AT, spanFrom(start))
             }
 
-
-            else -> {
+            // Identifiers and keywords
+            else -> if (char.isIdentifierStart()) {
+                lexIdentifierOrKeyword(start)
+            } else {
                 // Unknown character - consume and return as error
                 consume()
                 Token.simple(TokenKind.UNKNOWN, spanFrom(start))
@@ -315,7 +313,7 @@ class Lexer(
         consume()
 
         // Consume the rest of the identifier
-        consumeWhile { it in 'a'..'z' || it in 'A'..'Z' || it == '_' || it in '0'..'9' }
+        consumeWhile { it.isIdentifierContinue() }
 
         val text = source.substring(startIndex, index)
         val kind = keywordFor(text) ?: TokenKind.IDENTIFIER
@@ -1051,3 +1049,12 @@ fun tokenize(source: String): List<Token> = Lexer(source).tokenize()
  * returning only significant tokens.
  */
 fun tokenizeSignificant(source: String): List<Token> = Lexer(source).tokenizeSignificant()
+
+private fun Char.isIdentifierStart(): Boolean {
+    // Kotlin common does not expose the WGSL XID_Start table; keep this as a Unicode letter subset.
+    return this == '_' || this in 'a'..'z' || this in 'A'..'Z' || isLetter()
+}
+
+private fun Char.isIdentifierContinue(): Boolean {
+    return isIdentifierStart() || this in '0'..'9' || isDigit()
+}

--- a/wgsl/parser/src/commonMain/kotlin/parser/Parser.kt
+++ b/wgsl/parser/src/commonMain/kotlin/parser/Parser.kt
@@ -2052,7 +2052,7 @@ class Parser(
             TokenKind.SAMPLER, TokenKind.SAMPLER_COMPARISON, TokenKind.RAY_QUERY,
             TokenKind.TEXTURE_1D, TokenKind.TEXTURE_2D, TokenKind.TEXTURE_3D,
             TokenKind.TEXTURE_CUBE, TokenKind.TEXTURE_EXTERNAL,
-            TokenKind.BUILTIN, TokenKind.POSITION, TokenKind.VERTEX_INDEX, TokenKind.INSTANCE_INDEX,
+            TokenKind.BUILTIN, TokenKind.COMPUTE, TokenKind.POSITION, TokenKind.VERTEX_INDEX, TokenKind.INSTANCE_INDEX,
             TokenKind.FRONT_FACING, TokenKind.PRIMITIVE_INDEX, TokenKind.SAMPLE_INDEX,
             TokenKind.SAMPLE_MASK, TokenKind.VIEWPORT_INDEX, TokenKind.POINTSIZE,
             TokenKind.CLIP_DISTANCES, TokenKind.CULL_DISTANCES, TokenKind.DEVICE_INDEX,

--- a/wgsl/parser/src/commonTest/kotlin/lexer/LexerBasicTest.kt
+++ b/wgsl/parser/src/commonTest/kotlin/lexer/LexerBasicTest.kt
@@ -53,24 +53,27 @@ class LexerBasicTest : FunSpec({
             tokens[0].literal shouldBe "foo123"
         }
 
-        test("Non-ASCII characters are recognized as UNKNOWN, not part of identifier") {
+        test("Unicode letters are valid identifier characters") {
             val tokens = tokenize("fooébar")
-            // Expect: identifier "foo", unknown "é", identifier "bar", EOF
             val filtered = tokens.filter { !it.isEof }
-            filtered shouldHaveSize 3
+            filtered shouldHaveSize 1
             filtered[0].kind shouldBe TokenKind.IDENTIFIER
-            filtered[0].literal shouldBe "foo"
-            filtered[1].kind shouldBe TokenKind.UNKNOWN
-            filtered[2].kind shouldBe TokenKind.IDENTIFIER
-            filtered[2].literal shouldBe "bar"
+            filtered[0].literal shouldBe "fooébar"
         }
 
-        test("Unicode Chinese characters are recognized as UNKNOWN") {
+        test("Unicode identifiers can contain trailing digits") {
+            val tokens = tokenizeSignificant("θ2")
+            tokens shouldHaveSize 1
+            tokens[0].kind shouldBe TokenKind.IDENTIFIER
+            tokens[0].literal shouldBe "θ2"
+        }
+
+        test("Unicode Chinese characters are recognized as one identifier") {
             val tokens = tokenize("变量")
             val filtered = tokens.filter { !it.isEof }
-            filtered shouldHaveSize 2
-            filtered[0].kind shouldBe TokenKind.UNKNOWN
-            filtered[1].kind shouldBe TokenKind.UNKNOWN
+            filtered shouldHaveSize 1
+            filtered[0].kind shouldBe TokenKind.IDENTIFIER
+            filtered[0].literal shouldBe "变量"
         }
     }
 
@@ -123,4 +126,3 @@ class LexerBasicTest : FunSpec({
         }
     }
 })
-

--- a/wgsl/parser/src/commonTest/kotlin/parser/TypeResolverTest.kt
+++ b/wgsl/parser/src/commonTest/kotlin/parser/TypeResolverTest.kt
@@ -97,4 +97,29 @@ class TypeResolverTest : FunSpec({
         result.isSuccess shouldBe true
         result.resolvedUnit.declarations shouldHaveSize 1
     }
+
+    test("resolve unicode local identifiers and contextual keyword function calls") {
+        val source = """
+            var<storage> asdf: f32;
+
+            fn compute() -> f32 {
+              let θ2 = asdf + 9001.0;
+              return θ2;
+            }
+
+            @compute @workgroup_size(1, 1)
+            fn main() {
+              compute();
+            }
+        """.trimIndent()
+
+        val parseResult = parseWgslResult(source)
+        parseResult.isSuccess shouldBe true
+
+        val resolver = TypeResolver()
+        val result = resolver.resolve(parseResult.translationUnit)
+
+        result.isSuccess shouldBe true
+        result.unresolvedReferences shouldHaveSize 0
+    }
 })

--- a/wgsl/tests/docs/golden-expected-failures.md
+++ b/wgsl/tests/docs/golden-expected-failures.md
@@ -8,7 +8,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `glsl` | `6438-conflicting-idents.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `6772-unpack-expr-accesses.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `7048-multiple-dynamic-1.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `glsl` | `7995-unicode-idents.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `glsl` | `7995-unicode-idents.wgsl` | `comparison` | Unicode identifiers now parse and lower; generated output still differs from the golden. | `#16` |
 | `glsl` | `8820-multiple-local-invocation-index-id.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `9105-primitive-index-ordering.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `abstract-types-atomic.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -153,7 +153,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `hlsl` | `7048-multiple-dynamic-1.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `7048-multiple-dynamic-2.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `7048-multiple-dynamic-3.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `hlsl` | `7995-unicode-idents.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `hlsl` | `7995-unicode-idents.wgsl` | `comparison` | Unicode identifiers now parse and lower; generated output still differs from the golden. | `#16` |
 | `hlsl` | `8820-multiple-local-invocation-index-id.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `9105-primitive-index-ordering.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `abstract-types-atomic.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -294,7 +294,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `hlsl` | `workgroup-uniform-load.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `workgroup-var-init.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `6772-unpack-expr-accesses.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `ir` | `7995-unicode-idents.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `ir` | `7995-unicode-idents.wgsl` | `comparison` | Unicode identifiers now parse and lower; generated output still differs from the golden. | `#16` |
 | `ir` | `abstract-types-atomic.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `abstract-types-builtins.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `abstract-types-const.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -400,7 +400,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `msl` | `7048-multiple-dynamic-1.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `7048-multiple-dynamic-2.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `7048-multiple-dynamic-3.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `msl` | `7995-unicode-idents.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `msl` | `7995-unicode-idents.wgsl` | `comparison` | Unicode identifiers now parse and lower; generated output still differs from the golden. | `#16` |
 | `msl` | `8820-multiple-local-invocation-index-id.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `9105-primitive-index-ordering.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `abstract-types-atomic.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -541,7 +541,6 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `msl` | `workgroup-uniform-load.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `workgroup-var-init.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `6438-conflicting-idents.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `roundtrip` | `7995-unicode-idents.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `abstract-types-atomic.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `abstract-types-function-calls.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `abstract-types-return.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -626,7 +625,6 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `roundtrip` | `workgroup-uniform-load-atomic.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `workgroup-uniform-load.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `6438-conflicting-idents.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `wgsl` | `7995-unicode-idents.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `abstract-types-atomic.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `abstract-types-function-calls.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `abstract-types-return.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |

--- a/wgsl/tests/src/jvmTest/kotlin/io/ygdrasil/wgsl/tests/GoldenCompletenessTest.kt
+++ b/wgsl/tests/src/jvmTest/kotlin/io/ygdrasil/wgsl/tests/GoldenCompletenessTest.kt
@@ -29,6 +29,6 @@ class GoldenCompletenessTest : FunSpec({
     }
 
     test("expected golden failures are validated and versioned") {
-        GoldenExpectedFailures.load(rootDir).size shouldBe 705
+        GoldenExpectedFailures.load(rootDir).size shouldBe 703
     }
 })


### PR DESCRIPTION
Refs #16

## Scope
- Treat Unicode letters/digits as identifier characters in the WGSL lexer, preserving the existing bare underscore behavior.
- Allow the contextual compute token to be used as a primary expression so fn compute() can be called as compute().
- Add parser/type-resolution coverage for the 7995-unicode-idents.wgsl scenario.
- Reclassify 7995-unicode-idents.wgsl expected failures from type-resolution to comparison for generated backends, and remove the wgsl/roundtrip expected failures.

## Validation
- rtk ./gradlew :wgsl:parser:jvmTest :wgsl:parser:koverVerifyJvm
- GOLDEN_FILTER=7995-unicode-idents.wgsl rtk ./gradlew :wgsl:tests:jvmTest
- rtk ./gradlew :wgsl:tests:jvmTest
- git diff --check

## Review Agent
- Noether requested changes for broad keyword expression parsing.
- Follow-up review approved after scoping the parser change to TokenKind.COMPUTE.