### PR TITLE
Fix WGSL template parsing state leak

### DIFF
--- a/wgsl/parser/src/commonMain/kotlin/parser/Parser.kt
+++ b/wgsl/parser/src/commonMain/kotlin/parser/Parser.kt
@@ -132,7 +132,7 @@ class Parser(
     private var isInsideTemplate: Boolean
         get() = templateDepth > 0
         set(value) {
-            if (value) templateDepth++ else if (templateDepth > 0) templateDepth--
+            templateDepth = if (value) 1 else 0
         }
 
     /** The list of errors encountered during parsing. */

--- a/wgsl/parser/src/commonTest/kotlin/parser/TypeResolverTest.kt
+++ b/wgsl/parser/src/commonTest/kotlin/parser/TypeResolverTest.kt
@@ -122,4 +122,28 @@ class TypeResolverTest : FunSpec({
         result.isSuccess shouldBe true
         result.unresolvedReferences shouldHaveSize 0
     }
+
+    test("resolve relational expressions after nested template types") {
+        val source = """
+            struct AtomicStruct {
+                atomic_arr: array<atomic<i32>, 2>,
+            }
+
+            fn main() {
+                let value: i32 = 1i;
+                if value > 0i {
+                    return;
+                }
+            }
+        """.trimIndent()
+
+        val parseResult = parseWgslResult(source)
+        parseResult.isSuccess shouldBe true
+
+        val resolver = TypeResolver()
+        val result = resolver.resolve(parseResult.translationUnit)
+
+        result.isSuccess shouldBe true
+        result.unresolvedReferences shouldHaveSize 0
+    }
 })

--- a/wgsl/tests/docs/golden-expected-failures.md
+++ b/wgsl/tests/docs/golden-expected-failures.md
@@ -109,7 +109,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `glsl` | `msl-vpt.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `multiview.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `multiview_webgl.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `glsl` | `operators.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `glsl` | `operators.wgsl` | `lowering` | Parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`. | `#16` |
 | `glsl` | `overrides-atomicCompareExchangeWeak.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `overrides-ray-query.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `packed-vec3-bitcast.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -254,7 +254,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `hlsl` | `msl-vpt-formats-x3.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `msl-vpt-formats-x4.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `msl-vpt.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `hlsl` | `operators.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `hlsl` | `operators.wgsl` | `lowering` | Parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`. | `#16` |
 | `hlsl` | `packed-vec3-bitcast.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `padding.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `per-vertex.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -373,7 +373,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `ir` | `msl-vpt-formats-x2.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `msl-vpt-formats-x3.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `msl-vpt-formats-x4.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `ir` | `operators.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `ir` | `operators.wgsl` | `lowering` | Parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`. | `#16` |
 | `ir` | `policy-mix.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `quad.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `ray-query-no-init-tracking.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -501,7 +501,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `msl` | `msl-vpt-formats-x3.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `msl-vpt-formats-x4.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `msl-vpt.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `msl` | `operators.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `msl` | `operators.wgsl` | `lowering` | Parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`. | `#16` |
 | `msl` | `packed-vec3-bitcast.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `padding.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `per-vertex.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -603,7 +603,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `roundtrip` | `msl-vpt-formats-x3.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `msl-vpt-formats-x4.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `msl-vpt.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `roundtrip` | `operators.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `roundtrip` | `operators.wgsl` | `lowering` | Parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`. | `#16` |
 | `roundtrip` | `overrides-atomicCompareExchangeWeak.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `overrides-ray-query.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `packed-vec3-bitcast.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -687,7 +687,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `wgsl` | `msl-vpt-formats-x3.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `msl-vpt-formats-x4.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `msl-vpt.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `wgsl` | `operators.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `wgsl` | `operators.wgsl` | `lowering` | Parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`. | `#16` |
 | `wgsl` | `overrides-atomicCompareExchangeWeak.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `overrides-ray-query.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `packed-vec3-bitcast.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |

--- a/wgsl/tests/docs/golden-expected-failures.md
+++ b/wgsl/tests/docs/golden-expected-failures.md
@@ -145,7 +145,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `glsl` | `types_with_comments.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `unconsumed_vertex_outputs_frag.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `use-gl-ext-over-grad-workaround-if-instructed.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `glsl` | `workgroup-uniform-load-atomic.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `glsl` | `workgroup-uniform-load-atomic.wgsl` | `missing-golden` | Parser/resolver/lowering now pass; golden output still needs review and generation. | `#16` |
 | `glsl` | `workgroup-uniform-load.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `workgroup-var-init.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `6438-conflicting-idents.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -290,7 +290,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `hlsl` | `unconsumed_vertex_outputs_frag.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `unconsumed_vertex_outputs_vert.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `use-gl-ext-over-grad-workaround-if-instructed.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `hlsl` | `workgroup-uniform-load-atomic.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `hlsl` | `workgroup-uniform-load-atomic.wgsl` | `missing-golden` | Parser/resolver/lowering now pass; golden output still needs review and generation. | `#16` |
 | `hlsl` | `workgroup-uniform-load.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `workgroup-var-init.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `6772-unpack-expr-accesses.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -393,7 +393,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `ir` | `texture-external.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `type-inference.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `use-gl-ext-over-grad-workaround-if-instructed.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `ir` | `workgroup-uniform-load-atomic.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `ir` | `workgroup-uniform-load-atomic.wgsl` | `missing-golden` | Parser/resolver/lowering now pass; golden output still needs review and generation. | `#16` |
 | `ir` | `workgroup-uniform-load.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `6438-conflicting-idents.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `6772-unpack-expr-accesses.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -537,7 +537,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `msl` | `unconsumed_vertex_outputs_frag.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `unconsumed_vertex_outputs_vert.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `use-gl-ext-over-grad-workaround-if-instructed.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `msl` | `workgroup-uniform-load-atomic.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `msl` | `workgroup-uniform-load-atomic.wgsl` | `missing-golden` | Parser/resolver/lowering now pass; golden output still needs review and generation. | `#16` |
 | `msl` | `workgroup-uniform-load.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `workgroup-var-init.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `6438-conflicting-idents.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -622,7 +622,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `roundtrip` | `type-inference.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `unconsumed_vertex_outputs_frag.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `unconsumed_vertex_outputs_vert.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `roundtrip` | `workgroup-uniform-load-atomic.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `roundtrip` | `workgroup-uniform-load-atomic.wgsl` | `missing-golden` | Parser/resolver/lowering now pass; golden output still needs review and generation. | `#16` |
 | `roundtrip` | `workgroup-uniform-load.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `6438-conflicting-idents.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `abstract-types-atomic.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -706,5 +706,5 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `wgsl` | `type-inference.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `unconsumed_vertex_outputs_frag.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `unconsumed_vertex_outputs_vert.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `wgsl` | `workgroup-uniform-load-atomic.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `wgsl` | `workgroup-uniform-load-atomic.wgsl` | `missing-golden` | Parser/resolver/lowering now pass; golden output still needs review and generation. | `#16` |
 | `wgsl` | `workgroup-uniform-load.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |

--- a/wgsl/tests/docs/golden-missing-outputs.md
+++ b/wgsl/tests/docs/golden-missing-outputs.md
@@ -43,7 +43,7 @@ Current status: 43 inputs are missing expected outputs for `wgsl`, `glsl`, `hlsl
 - `mesh-shader-empty.wgsl` - pending parser/resolver/lowering support.
 - `mesh-shader-lines.wgsl` - pending parser/resolver/lowering support.
 - `mesh-shader-points.wgsl` - pending parser/resolver/lowering support.
-- `operators.wgsl` - pending parser/resolver/lowering support.
+- `operators.wgsl` - parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`.
 - `quad.wgsl` - pending parser/resolver/lowering support.
 - `ray-query.wgsl` - pending parser/resolver/lowering support.
 - `ray-query-no-init-tracking.wgsl` - pending parser/resolver/lowering support.

--- a/wgsl/tests/docs/golden-missing-outputs.md
+++ b/wgsl/tests/docs/golden-missing-outputs.md
@@ -48,4 +48,4 @@ Current status: 43 inputs are missing expected outputs for `wgsl`, `glsl`, `hlsl
 - `ray-query.wgsl` - pending parser/resolver/lowering support.
 - `ray-query-no-init-tracking.wgsl` - pending parser/resolver/lowering support.
 - `type-inference.wgsl` - pending parser/resolver/lowering support.
-- `workgroup-uniform-load-atomic.wgsl` - pending parser/resolver/lowering support.
+- `workgroup-uniform-load-atomic.wgsl` - parser/resolver/lowering support now passes; golden output needs review and generation.


### PR DESCRIPTION
Refs #16

## Scope
- Fix the parser template-state save/restore behavior so nested template types do not leak template context into later expressions.
- Add a resolver regression test for a nested array/atomic type followed by a relational greater-than expression.
- Reclassify workgroup-uniform-load-atomic.wgsl from type-resolution to missing-golden across golden suites.
- Update the missing-output note to reflect that parser/resolver/lowering now pass and outputs need review/generation.

## Validation
- rtk ./gradlew :wgsl:parser:jvmTest :wgsl:parser:koverVerifyJvm
- GOLDEN_FILTER=workgroup-uniform-load-atomic.wgsl rtk ./gradlew :wgsl:tests:jvmTest
- rtk ./gradlew :wgsl:tests:jvmTest
- git diff --check

## Review Agent
- Planck reviewed the local diff and returned APPROVE_MERGE.