### PR TITLE
[codex] Add JVM fast path for non-master PRs

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -2,6 +2,8 @@ name: Qodana
 on:
   workflow_dispatch:
   pull_request:
+    branches:
+      - master
   push:
     branches: # Specify your branches here
       - main # The 'main' branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   tests:
+    if: github.event_name != 'pull_request' || github.base_ref == 'master'
     strategy:
       fail-fast: false
       matrix:
@@ -41,3 +42,34 @@ jobs:
       - name: Build & Test
         run: ./gradlew check
 
+  jvm-fast-path:
+    if: github.event_name == 'pull_request' && github.base_ref != 'master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 25
+          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: JVM Tests
+        run: >
+          ./gradlew
+          :webgpu-ktypes:jvmTest
+          :webgpu-ktypes-descriptors:jvmTest
+          :webgpu-ktypes-specifications:jvmTest
+          :wgsl:cli:jvmTest
+          :wgsl:core:jvmTest
+          :wgsl:generator:jvmTest
+          :wgsl:parser:jvmTest
+          :wgsl:parser:koverVerifyJvm
+          :wgsl:tests:jvmTest


### PR DESCRIPTION
## Summary

Adds a CI fast path for pull requests that do not target `master`.

## Changes

- Keeps the full `./gradlew check` matrix on macOS, Ubuntu, and Windows for pushes and PRs targeting `master`.
- Adds a `jvm-fast-path` job for PRs targeting non-`master` branches.
- Runs all JVM test tasks plus `:wgsl:parser:koverVerifyJvm` in the fast path.
- Limits Qodana PR runs to `master` so intermediate integration PRs are not blocked by the heavier quality scan.

## Validation

- Parsed `.github/workflows/test.yml` and `.github/workflows/qodana_code_quality.yml` with Ruby YAML.
- Ran the fast-path command locally:
  `rtk ./gradlew :webgpu-ktypes:jvmTest :webgpu-ktypes-descriptors:jvmTest :webgpu-ktypes-specifications:jvmTest :wgsl:cli:jvmTest :wgsl:core:jvmTest :wgsl:generator:jvmTest :wgsl:parser:jvmTest :wgsl:parser:koverVerifyJvm :wgsl:tests:jvmTest --no-build-cache`
