### PR TITLE
Fix inferred global const lowering

### DIFF
--- a/wgsl/parser/src/commonMain/kotlin/parser/Lowerer.kt
+++ b/wgsl/parser/src/commonMain/kotlin/parser/Lowerer.kt
@@ -433,30 +433,35 @@ class Lowerer {
     }
 
     private fun lowerGlobalVariable(decl: VariableDecl) {
-        val type = decl.type?.let { lowerType(it) } ?: return
-        
+        val initHandle = decl.initializer?.let { initializerExpr ->
+            val savedExpressions = currentExpressions
+            try {
+                currentExpressions = module.globalExpressions
+                lowerExpression(initializerExpr)
+            } finally {
+                currentExpressions = savedExpressions
+            }
+        }
+
+        val type = decl.type?.let { lowerType(it) }
+            ?: initHandle?.let { handle ->
+                val savedExpressions = currentExpressions
+                try {
+                    currentExpressions = module.globalExpressions
+                    resolveExpressionType(handle)
+                } finally {
+                    currentExpressions = savedExpressions
+                }
+            }
+            ?: return
+
         val storageClass = if (decl.storageClass != null) {
             lowerStorageClassText(decl.storageClass)
         } else {
             lowerStorageClass(decl.kind.toStorageClass())
         }
-        
-        val accessMode = lowerAccessModeText(decl.accessMode)
 
-        // Lower the initializer if present (P003 fix)
-        val initHandle = decl.initializer?.let { initializerExpr ->
-            val savedExpressions = currentExpressions
-            try {
-                // Use global expressions arena for global variable initializers
-                currentExpressions = module.globalExpressions
-                val result = lowerExpression(initializerExpr)
-                currentExpressions = savedExpressions
-                result
-            } catch (e: Exception) {
-                currentExpressions = savedExpressions
-                throw e
-            }
-        }
+        val accessMode = lowerAccessModeText(decl.accessMode)
 
         val group = decl.attributes.find { it.name == "group" }?.let {
             (it.args.firstOrNull() as? IntLiteral)?.value?.toInt()

--- a/wgsl/parser/src/commonTest/kotlin/parser/lower/GlobalLoweringTest.kt
+++ b/wgsl/parser/src/commonTest/kotlin/parser/lower/GlobalLoweringTest.kt
@@ -4,7 +4,12 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ygdrasil.wgsl.ir.ExpressionKind
+import io.ygdrasil.wgsl.ir.Statement
 import io.ygdrasil.wgsl.ir.StorageClass
+import io.ygdrasil.wgsl.ir.TypeInner
+import io.ygdrasil.wgsl.ir.VectorSize
 import io.ygdrasil.wgsl.parser.lowerWgsl
 
 class GlobalLoweringTest : FunSpec({
@@ -36,5 +41,28 @@ class GlobalLoweringTest : FunSpec({
         
         val globalVar = module.globalVariables.toList().first()
         globalVar.init shouldNotBe null
+    }
+
+    test("global_const_with_inferred_type_should_be_available_to_functions") {
+        val module = lowerWgsl("""
+            const v_f32_zero = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+
+            fn main() -> vec4<f32> {
+                return v_f32_zero;
+            }
+        """.trimIndent())
+
+        module.globalVariables.toList() shouldHaveSize 1
+        val globalVar = module.globalVariables.toList().first()
+        globalVar.name shouldBe "v_f32_zero"
+        globalVar.init shouldNotBe null
+
+        val globalType = module.types[globalVar.type].inner.shouldBeInstanceOf<TypeInner.Vector>()
+        globalType.size shouldBe VectorSize.Quad
+
+        val function = module.functions.toList().single { it.name == "main" }
+        val returnStatement = function.blocks[function.body].statements.single().shouldBeInstanceOf<Statement.Return>()
+        val returnExpression = function.expressions[returnStatement.value!!]
+        returnExpression.kind.shouldBeInstanceOf<ExpressionKind.GlobalVar>()
     }
 })

--- a/wgsl/tests/docs/golden-expected-failures.md
+++ b/wgsl/tests/docs/golden-expected-failures.md
@@ -14,12 +14,12 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `glsl` | `abstract-types-atomic.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `abstract-types-builtins.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `abstract-types-const.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `glsl` | `abstract-types-function-calls.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `glsl` | `abstract-types-function-calls.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `glsl` | `abstract-types-let.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `abstract-types-operators.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `glsl` | `abstract-types-return.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `glsl` | `abstract-types-return.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `glsl` | `abstract-types-texture.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `glsl` | `abstract-types-var.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `glsl` | `abstract-types-var.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `glsl` | `access.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `aliased-ray-query.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `array-in-ctor.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -52,11 +52,11 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `glsl` | `clip-distances.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `collatz.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `const-exprs.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `glsl` | `const_assert.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `glsl` | `const_assert.wgsl` | `comparison` | Parser/resolver/lowering now pass after inferred global const lowering fix; generated output still differs from golden. | `#16` |
 | `glsl` | `constructors.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `control-flow.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `glsl` | `conversion-float-to-int-no-f64.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `glsl` | `conversion-float-to-int.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `glsl` | `conversion-float-to-int-no-f64.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
+| `glsl` | `conversion-float-to-int.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `glsl` | `cooperative-matrix.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `cross.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `cubeArrayShadow.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -88,7 +88,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `glsl` | `interpolate.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `interpolate_compat.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `invariant.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `glsl` | `local-const.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `glsl` | `local-const.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `glsl` | `mat2-uniform-alignment.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `mat_cx2.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `mat_cx2_f16.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -109,7 +109,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `glsl` | `msl-vpt.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `multiview.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `multiview_webgl.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `glsl` | `operators.wgsl` | `lowering` | Parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`. | `#16` |
+| `glsl` | `operators.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `glsl` | `overrides-atomicCompareExchangeWeak.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `overrides-ray-query.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `packed-vec3-bitcast.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -141,7 +141,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `glsl` | `texture-arg.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `texture-external.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `type-alias.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `glsl` | `type-inference.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `glsl` | `type-inference.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `glsl` | `types_with_comments.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `unconsumed_vertex_outputs_frag.wgsl` | `native-validation` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `glsl` | `use-gl-ext-over-grad-workaround-if-instructed.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -159,12 +159,12 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `hlsl` | `abstract-types-atomic.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `abstract-types-builtins.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `abstract-types-const.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `hlsl` | `abstract-types-function-calls.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `hlsl` | `abstract-types-function-calls.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `hlsl` | `abstract-types-let.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `abstract-types-operators.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `hlsl` | `abstract-types-return.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `hlsl` | `abstract-types-return.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `hlsl` | `abstract-types-texture.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `hlsl` | `abstract-types-var.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `hlsl` | `abstract-types-var.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `hlsl` | `access.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `aliased-ray-query.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `array-in-ctor.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -198,11 +198,11 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `hlsl` | `clip-distances.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `collatz.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `const-exprs.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `hlsl` | `const_assert.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `hlsl` | `const_assert.wgsl` | `comparison` | Parser/resolver/lowering now pass after inferred global const lowering fix; generated output still differs from golden. | `#16` |
 | `hlsl` | `constructors.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `control-flow.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `hlsl` | `conversion-float-to-int-no-f64.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `hlsl` | `conversion-float-to-int.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `hlsl` | `conversion-float-to-int-no-f64.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
+| `hlsl` | `conversion-float-to-int.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `hlsl` | `conversions.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `cooperative-matrix.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `cross.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -237,7 +237,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `hlsl` | `interpolate.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `interpolate_compat.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `invariant.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `hlsl` | `local-const.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `hlsl` | `local-const.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `hlsl` | `mat2-uniform-alignment.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `mat_cx2_f16.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `math-functions.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -254,7 +254,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `hlsl` | `msl-vpt-formats-x3.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `msl-vpt-formats-x4.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `msl-vpt.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `hlsl` | `operators.wgsl` | `lowering` | Parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`. | `#16` |
+| `hlsl` | `operators.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `hlsl` | `packed-vec3-bitcast.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `padding.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `per-vertex.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -286,7 +286,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `hlsl` | `texture-arg.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `texture-external.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `type-alias.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `hlsl` | `type-inference.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `hlsl` | `type-inference.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `hlsl` | `unconsumed_vertex_outputs_frag.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `unconsumed_vertex_outputs_vert.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `hlsl` | `use-gl-ext-over-grad-workaround-if-instructed.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -298,12 +298,12 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `ir` | `abstract-types-atomic.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `abstract-types-builtins.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `abstract-types-const.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `ir` | `abstract-types-function-calls.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `ir` | `abstract-types-function-calls.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `ir` | `abstract-types-let.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `abstract-types-operators.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `ir` | `abstract-types-return.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `ir` | `abstract-types-return.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `ir` | `abstract-types-texture.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `ir` | `abstract-types-var.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `ir` | `abstract-types-var.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `ir` | `access.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `aliased-ray-query.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `atomicCompareExchange-int64.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -331,11 +331,11 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `ir` | `break-if.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `collatz.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `const-exprs.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `ir` | `const_assert.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `ir` | `const_assert.wgsl` | `comparison` | Parser/resolver/lowering now pass after inferred global const lowering fix; generated output still differs from golden. | `#16` |
 | `ir` | `constructors.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `control-flow.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `ir` | `conversion-float-to-int-no-f64.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `ir` | `conversion-float-to-int.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `ir` | `conversion-float-to-int-no-f64.wgsl` | `code-generation` | Parser/resolver/lowering now pass after inferred global const lowering fix; IR JSON generation still fails on non-finite float values. | `#16` |
+| `ir` | `conversion-float-to-int.wgsl` | `code-generation` | Parser/resolver/lowering now pass after inferred global const lowering fix; IR JSON generation still fails on non-finite float values. | `#16` |
 | `ir` | `cooperative-matrix.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `cross.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `cubeArrayShadow.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -359,7 +359,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `ir` | `interface.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `interpolate.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `interpolate_compat.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `ir` | `local-const.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `ir` | `local-const.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `ir` | `mat_cx2.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `mat_cx2_f16.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `mat_cx3.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -373,7 +373,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `ir` | `msl-vpt-formats-x2.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `msl-vpt-formats-x3.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `msl-vpt-formats-x4.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `ir` | `operators.wgsl` | `lowering` | Parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`. | `#16` |
+| `ir` | `operators.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `ir` | `policy-mix.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `quad.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `ray-query-no-init-tracking.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -391,7 +391,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `ir` | `subgroup-operations.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `texture-arg.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `texture-external.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `ir` | `type-inference.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `ir` | `type-inference.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `ir` | `use-gl-ext-over-grad-workaround-if-instructed.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `ir` | `workgroup-uniform-load-atomic.wgsl` | `missing-golden` | Parser/resolver/lowering now pass; golden output still needs review and generation. | `#16` |
 | `ir` | `workgroup-uniform-load.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -406,12 +406,12 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `msl` | `abstract-types-atomic.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `abstract-types-builtins.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `abstract-types-const.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `msl` | `abstract-types-function-calls.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `msl` | `abstract-types-function-calls.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `msl` | `abstract-types-let.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `abstract-types-operators.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `msl` | `abstract-types-return.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `msl` | `abstract-types-return.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `msl` | `abstract-types-texture.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `msl` | `abstract-types-var.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `msl` | `abstract-types-var.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `msl` | `access.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `aliased-ray-query.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `array-in-ctor.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -445,11 +445,11 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `msl` | `clip-distances.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `collatz.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `const-exprs.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `msl` | `const_assert.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `msl` | `const_assert.wgsl` | `comparison` | Parser/resolver/lowering now pass after inferred global const lowering fix; generated output still differs from golden. | `#16` |
 | `msl` | `constructors.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `control-flow.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `msl` | `conversion-float-to-int-no-f64.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `msl` | `conversion-float-to-int.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `msl` | `conversion-float-to-int-no-f64.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
+| `msl` | `conversion-float-to-int.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `msl` | `conversions.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `cooperative-matrix.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `cross.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -484,7 +484,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `msl` | `interpolate.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `interpolate_compat.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `invariant.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `msl` | `local-const.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `msl` | `local-const.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `msl` | `mat2-uniform-alignment.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `mat_cx2_f16.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `math-functions.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -501,7 +501,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `msl` | `msl-vpt-formats-x3.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `msl-vpt-formats-x4.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `msl-vpt.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `msl` | `operators.wgsl` | `lowering` | Parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`. | `#16` |
+| `msl` | `operators.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `msl` | `packed-vec3-bitcast.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `padding.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `per-vertex.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -533,7 +533,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `msl` | `texture-arg.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `texture-external.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `type-alias.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `msl` | `type-inference.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `msl` | `type-inference.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `msl` | `unconsumed_vertex_outputs_frag.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `unconsumed_vertex_outputs_vert.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `msl` | `use-gl-ext-over-grad-workaround-if-instructed.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -542,10 +542,10 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `msl` | `workgroup-var-init.wgsl` | `comparison` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `6438-conflicting-idents.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `abstract-types-atomic.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `roundtrip` | `abstract-types-function-calls.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `roundtrip` | `abstract-types-return.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `roundtrip` | `abstract-types-function-calls.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
+| `roundtrip` | `abstract-types-return.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `roundtrip` | `abstract-types-texture.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `roundtrip` | `abstract-types-var.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `roundtrip` | `abstract-types-var.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `roundtrip` | `access.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `aliased-ray-query.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `atomicCompareExchange-int64.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -564,10 +564,9 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `roundtrip` | `break-if.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `clip-distances.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `const-exprs.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `roundtrip` | `const_assert.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `control-flow.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `roundtrip` | `conversion-float-to-int-no-f64.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `roundtrip` | `conversion-float-to-int.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `roundtrip` | `conversion-float-to-int-no-f64.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
+| `roundtrip` | `conversion-float-to-int.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `roundtrip` | `cooperative-matrix.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `debug-symbol-large-source.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `debug-symbol-simple.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -591,7 +590,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `roundtrip` | `interpolate.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `interpolate_compat.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `lexical-scopes.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `roundtrip` | `local-const.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `roundtrip` | `local-const.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `roundtrip` | `math-functions.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `mesh-shader-empty.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `mesh-shader-lines.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -603,7 +602,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `roundtrip` | `msl-vpt-formats-x3.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `msl-vpt-formats-x4.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `msl-vpt.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `roundtrip` | `operators.wgsl` | `lowering` | Parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`. | `#16` |
+| `roundtrip` | `operators.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `roundtrip` | `overrides-atomicCompareExchangeWeak.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `overrides-ray-query.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `packed-vec3-bitcast.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -619,17 +618,17 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `roundtrip` | `shadow.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `skybox.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `struct-layout.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `roundtrip` | `type-inference.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `roundtrip` | `type-inference.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `roundtrip` | `unconsumed_vertex_outputs_frag.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `unconsumed_vertex_outputs_vert.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `roundtrip` | `workgroup-uniform-load-atomic.wgsl` | `missing-golden` | Parser/resolver/lowering now pass; golden output still needs review and generation. | `#16` |
 | `roundtrip` | `workgroup-uniform-load.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `6438-conflicting-idents.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `abstract-types-atomic.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `wgsl` | `abstract-types-function-calls.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `wgsl` | `abstract-types-return.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `wgsl` | `abstract-types-function-calls.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
+| `wgsl` | `abstract-types-return.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `wgsl` | `abstract-types-texture.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `wgsl` | `abstract-types-var.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `wgsl` | `abstract-types-var.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `wgsl` | `access.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `aliased-ray-query.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `atomicCompareExchange-int64.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -648,10 +647,9 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `wgsl` | `break-if.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `clip-distances.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `const-exprs.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `wgsl` | `const_assert.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `control-flow.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `wgsl` | `conversion-float-to-int-no-f64.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `wgsl` | `conversion-float-to-int.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `wgsl` | `conversion-float-to-int-no-f64.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
+| `wgsl` | `conversion-float-to-int.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `wgsl` | `cooperative-matrix.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `debug-symbol-large-source.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `debug-symbol-simple.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -675,7 +673,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `wgsl` | `interpolate.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `interpolate_compat.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `lexical-scopes.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `wgsl` | `local-const.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `wgsl` | `local-const.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `wgsl` | `math-functions.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `mesh-shader-empty.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `mesh-shader-lines.wgsl` | `type-resolution` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -687,7 +685,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `wgsl` | `msl-vpt-formats-x3.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `msl-vpt-formats-x4.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `msl-vpt.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `wgsl` | `operators.wgsl` | `lowering` | Parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`. | `#16` |
+| `wgsl` | `operators.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `wgsl` | `overrides-atomicCompareExchangeWeak.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `overrides-ray-query.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `packed-vec3-bitcast.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
@@ -703,7 +701,7 @@ Each listed case is still executed. The test fails if the case starts passing un
 | `wgsl` | `shadow.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `skybox.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `struct-layout.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
-| `wgsl` | `type-inference.wgsl` | `lowering` | Baseline debt from issue 16 golden stabilization. | `#16` |
+| `wgsl` | `type-inference.wgsl` | `missing-golden` | Parser/resolver/lowering now pass after inferred global const lowering fix; golden output still needs review and generation. | `#16` |
 | `wgsl` | `unconsumed_vertex_outputs_frag.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `unconsumed_vertex_outputs_vert.wgsl` | `roundtrip-semantic-isomorphism` | Baseline debt from issue 16 golden stabilization. | `#16` |
 | `wgsl` | `workgroup-uniform-load-atomic.wgsl` | `missing-golden` | Parser/resolver/lowering now pass; golden output still needs review and generation. | `#16` |

--- a/wgsl/tests/docs/golden-missing-outputs.md
+++ b/wgsl/tests/docs/golden-missing-outputs.md
@@ -6,9 +6,9 @@ are either generated and reviewed or moved to a narrower unsupported-feature man
 
 Current status: 43 inputs are missing expected outputs for `wgsl`, `glsl`, `hlsl`, `msl`, and `ir`.
 
-- `abstract-types-function-calls.wgsl` - pending parser/resolver/lowering support.
-- `abstract-types-return.wgsl` - pending parser/resolver/lowering support.
-- `abstract-types-var.wgsl` - pending parser/resolver/lowering support.
+- `abstract-types-function-calls.wgsl` - parser/resolver/lowering support now passes after inferred global const lowering fix; golden output needs review and generation.
+- `abstract-types-return.wgsl` - parser/resolver/lowering support now passes after inferred global const lowering fix; golden output needs review and generation.
+- `abstract-types-var.wgsl` - parser/resolver/lowering support now passes after inferred global const lowering fix; golden output needs review and generation.
 - `aliased-ray-query.wgsl` - pending parser/resolver/lowering support.
 - `atomicCompareExchange.wgsl` - pending parser/resolver/lowering support.
 - `atomicCompareExchange-int64.wgsl` - pending parser/resolver/lowering support.
@@ -23,8 +23,8 @@ Current status: 43 inputs are missing expected outputs for `wgsl`, `glsl`, `hlsl
 - `break-if.wgsl` - pending parser/resolver/lowering support.
 - `const-exprs.wgsl` - pending parser/resolver/lowering support.
 - `control-flow.wgsl` - pending parser/resolver/lowering support.
-- `conversion-float-to-int.wgsl` - pending parser/resolver/lowering support.
-- `conversion-float-to-int-no-f64.wgsl` - pending parser/resolver/lowering support.
+- `conversion-float-to-int.wgsl` - parser/resolver/lowering support now passes after inferred global const lowering fix; golden output needs review and generation.
+- `conversion-float-to-int-no-f64.wgsl` - parser/resolver/lowering support now passes after inferred global const lowering fix; golden output needs review and generation.
 - `cooperative-matrix.wgsl` - pending parser/resolver/lowering support.
 - `debug-symbol-large-source.wgsl` - pending parser/resolver/lowering support.
 - `debug-symbol-terrain.wgsl` - pending parser/resolver/lowering support.
@@ -37,15 +37,15 @@ Current status: 43 inputs are missing expected outputs for `wgsl`, `glsl`, `hlsl
 - `int64.wgsl` - pending parser/resolver/lowering support.
 - `interpolate.wgsl` - pending parser/resolver/lowering support.
 - `interpolate_compat.wgsl` - pending parser/resolver/lowering support.
-- `local-const.wgsl` - pending parser/resolver/lowering support.
+- `local-const.wgsl` - parser/resolver/lowering support now passes after inferred global const lowering fix; golden output needs review and generation.
 - `math-functions.wgsl` - pending parser/resolver/lowering support.
 - `mesh-shader.wgsl` - pending parser/resolver/lowering support.
 - `mesh-shader-empty.wgsl` - pending parser/resolver/lowering support.
 - `mesh-shader-lines.wgsl` - pending parser/resolver/lowering support.
 - `mesh-shader-points.wgsl` - pending parser/resolver/lowering support.
-- `operators.wgsl` - parser/type-resolution now reach lowering after template-state fix; lowering still fails on undefined variable `v_f32_zero`.
+- `operators.wgsl` - parser/resolver/lowering support now passes after inferred global const lowering fix; golden output needs review and generation.
 - `quad.wgsl` - pending parser/resolver/lowering support.
 - `ray-query.wgsl` - pending parser/resolver/lowering support.
 - `ray-query-no-init-tracking.wgsl` - pending parser/resolver/lowering support.
-- `type-inference.wgsl` - pending parser/resolver/lowering support.
+- `type-inference.wgsl` - parser/resolver/lowering support now passes after inferred global const lowering fix; golden output needs review and generation.
 - `workgroup-uniform-load-atomic.wgsl` - parser/resolver/lowering support now passes; golden output needs review and generation.

--- a/wgsl/tests/src/jvmTest/kotlin/io/ygdrasil/wgsl/tests/GoldenCompletenessTest.kt
+++ b/wgsl/tests/src/jvmTest/kotlin/io/ygdrasil/wgsl/tests/GoldenCompletenessTest.kt
@@ -29,6 +29,6 @@ class GoldenCompletenessTest : FunSpec({
     }
 
     test("expected golden failures are validated and versioned") {
-        GoldenExpectedFailures.load(rootDir).size shouldBe 703
+        GoldenExpectedFailures.load(rootDir).size shouldBe 701
     }
 })


### PR DESCRIPTION
Refs #16

## Summary
- lower global variable initializers before deciding whether an inferred global has a type
- infer global const/var types from initializer expressions in the global expression arena
- add a lowering regression test for an inferred global const referenced from a function
- reclassify newly advanced golden cases and update the expected failure count from 703 to 701

## Golden manifest updates
- moves `operators.wgsl`, abstract type cases, local const/type inference, and float-to-int conversion cases past lowering
- marks missing generated outputs where parser/resolver/lowering now pass
- moves `const_assert.wgsl` backend rows to comparison and removes now-passing WGSL/roundtrip expected failures

## Validation
- `rtk ./gradlew :wgsl:parser:jvmTest --tests 'io.ygdrasil.wgsl.parser.lower.GlobalLoweringTest'`\n- `rtk ./gradlew :wgsl:parser:jvmTest :wgsl:parser:koverVerifyJvm`\n- `GOLDEN_FILTER=operators.wgsl rtk ./gradlew :wgsl:tests:jvmTest --rerun-tasks --no-build-cache`\n- `rtk ./gradlew :wgsl:tests:jvmTest --rerun-tasks --no-build-cache`\n- `git diff --check`\n- independent review agent: `APPROVE_MERGE`